### PR TITLE
Update README and Configure HTML Proofer to Be Stricter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ rvm:
   - 2.3.0
 
 install: bundle install # Install needed gems
-script: ci.sh # Run continuous integration shell script
+script: ./ci.sh # Run continuous integration shell script
 
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+# Cache gems
+cache: bundler
 
 sudo: false # route your build to the container-based infrastructure for a faster build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Travis configuration file
-# Environment and script configuration copied from Jekyll Continuous Integration Guide (see https://jekyllrb.com/docs/continuous-integration/)
+# Some configuration copied from Jekyll Continuous Integration Guide
+# See https://jekyllrb.com/docs/continuous-integration/travis-ci/
 language: ruby
 rvm:
   - 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ rvm:
   - 2.3.0
 
 install: bundle install # Install needed gems
-script: jekyll build && htmlproofer ./_site --assume-extension --allow-hash-href --http-status-ignore "999" # Build with Jekyll & test with HTML Proofer
-
-# In particular these HTML Proofer parameters
-# --assume-extension    - Fix needing the .html extension on links
-# --allow-hash-href     - Fix href="#" being marked as invalid
-# --http-status-ignore "999" - Ignore broken links with no error (caused by LinkedIn)
+script: ci.sh # Run continuous integration shell script
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,42 @@
 
 My personal website, used for everything from showcasing work to prototyping and messing around with HTML. Have suggetions or feedback? Open an issue.
 
+## Running
+
+This project uses [Jekyll]([Jekyll](https://jekyllrb.com/)), so to run it
+locally simply do:
+
+```shell
+bundle install # install all gems
+jekyll serve # host the site locall
+```
+
+The site should be hosted for you at `localhost:4000`.
+
+## Testing
+
+This site uses Travis for CI, but you can run the CI locally by running:
+
+```shell
+./ci.sh
+```
+
+This will build the Jekyll site and then run it through validation with
+[HTML Proofer](https://github.com/gjtorikian/html-proofer).
+
 ## Features
+
 - Gallery - Powered by jQuery and some nifty CSS3, this animated gallery shows off some visual parts of my work, including a way to view titles and descriptions. The gallery images are dynamically loaded in using Javascript.
+
 - Portfolio - List of projects, each with its own gallery of images, description, and set of tools. This is also dynamically generated using Javascript instead of being stored in the DOM.
+
 - Blog - Jekyll powered blog, used for technical posts with well formatted code snippets.
 
 ## Notable Pages
+
 - [Apollo](http://viktorkoves.com/apollo) - Spotify API powered tool for learning more about songs. It is now hosted on [its own repository](https://github.com/vkoves/apollo).
-- [The Transportation Collective](http://viktorkoves.com/TransportationCollective/) - A big data capture and analysis tool designed for use with the CTA. It is hosted on [its own repository](https://github.com/vkoves/TransportationCollective).
 
 ## Technology
-This website is powered by [Jekyll](https://jekyllrb.com/), and uses custom CSS and jQuery for just about everything. You can use `jekyll serve` to run it locally, or can [view it live](http://viktorkoves.com/).
+
+This website is powered by [Jekyll](https://jekyllrb.com/), and uses custom CSS
+and jQuery for just about everything.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ This will build the Jekyll site and then run it through validation with
 
 ## Notable Pages
 
-- [Apollo](http://viktorkoves.com/apollo) - Spotify API powered tool for learning more about songs. It is now hosted on [its own repository](https://github.com/vkoves/apollo).
+- [Apollo](http://viktorkoves.com/apollo) -
+	Spotify API powered tool for learning more about songs. It is now hosted on [its own repository](https://github.com/vkoves/apollo).
+- [Christmas In Clouds](https://viktorkoves.com/projects/christmas-in-clouds/) -
+	The homepage for a festive game I made for the holidays in the Unity game engine.
 
 ## Technology
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,7 +72,6 @@
 	  ga('create', 'UA-39148744-3', 'auto');
 	  ga('send', 'pageview');
 	</script>
-	<script type='text/javascript' src='//platform-api.sharethis.com/js/sharethis.js#property=5907fb614bb15c0012f0c2d5&product=inline-share-buttons' async='async'></script>
 </head>
 <body>
 	{% comment %} Site wide header {% endcomment %}

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,15 @@
+# Continuous Integration - run by Travis or can be run locally
+
+# Run Jekyll build to generate site output
+jekyll build
+
+# Run HTML Proofer with the following parameters:
+#
+# --allow-hash-href				- Fix href="#" being marked as invalid
+# --assume-extension			- Fix needing the .html extension on links
+# --check_html					- Check for HTML errors using Nokogiri
+# --enforce_https				- Enforce HTTPS (since hosted on HTTPS)
+# --http-status-ignore "999"	- Ignore broken links with no error (caused by LinkedIn)
+#
+# Learn more: https://github.com/gjtorikian/html-proofer#configuration
+htmlproofer ./_site --allow-hash-href --assume-extension --check-html --http-status-ignore "999"

--- a/projects/christmas-in-clouds/css/main.css
+++ b/projects/christmas-in-clouds/css/main.css
@@ -195,6 +195,7 @@ section.two-col img {
 
 #download-sect a {
 	text-decoration: none;
+	font-weight: bold;
 	color: inherit;
 }
 

--- a/projects/christmas-in-clouds/index.html
+++ b/projects/christmas-in-clouds/index.html
@@ -58,8 +58,8 @@
 					</p>
 				</div>
 				<img src="./img/screenshot-4-sq.png" alt="Christmas in Clouds Screenshot">
-			</section>
-		</div>
+			</div>
+		</section>
 		<section class="two-col">
 			<div class="inner">
 				<div class="text">

--- a/projects/christmas-in-clouds/index.html
+++ b/projects/christmas-in-clouds/index.html
@@ -134,7 +134,7 @@
 					</div>
 				</section>
 				<div class="small-text" id="download">
-					Having issues playing the game? Reach out to us on <a href="https://www.facebook.com/indigoBoxStudios/">Facebook</a> or Twitter <a href="https://twitter.com/indigobox">@indigobox</a>
+					Having issues playing the game? Reach out to me on Twitter <a href="https://twitter.com/viktor_koves">@viktor_koves</a>!
 				</div>
 			</center>
 		</div>

--- a/valentines2016.html
+++ b/valentines2016.html
@@ -70,8 +70,7 @@
    xmlns="http://www.w3.org/2000/svg"
    version="1.0"
    width="645"
-   height="585"
-   id="svg2">
+   height="585">
 	  <defs
 	     id="defs4" />
 	  <g


### PR DESCRIPTION
This PR does a few significant things:

1. Updates the README to provide more information on running the site locally and testing.
2. Moves build and testing out to a new `ci.sh` file so that it can be properly split out and documented, and be run locally.
3. Makes HTML Proofer stricter by enabling `check_html` and `enforce_https`. 