### PR TITLE
Improve Gallery Accessibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -9,6 +9,7 @@ body
 	background: #f3f3f3;
 	font-size: 16px;
 }
+button { font-family: 'Open Sans', sans-serif; }
 .page-limiter
 {
 	position: relative;
@@ -219,8 +220,10 @@ h4 { font-weight: 600; margin-top: 10px; }
 	display: inline-block;
 	background-color: lightgrey;
 	padding: 3px 15px;
+	border: none;
 	border-radius: 5px;
 	color: #272727;
+	font-size: 16px;
 	font-weight: 600;
 	cursor: pointer;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -406,7 +406,8 @@ h4 { font-weight: 600; margin-top: 10px; }
 	display: inline;
 	position: relative;
 }
-#overlay-main .icon
+/* Style overlay info icon */
+#overlay-main .icon.info
 {
     position: absolute;
     width: 50px;
@@ -419,10 +420,21 @@ h4 { font-weight: 600; margin-top: 10px; }
     background-color: rgba(0,0,0,0.95);
     cursor: pointer;
     border-top-left-radius: 15px;
+    border: none;
     opacity: 0.5;
     transition: opacity 0.3s;
 }
-#overlay-main .icon:hover { opacity: 1; }
+/* On focus and hover make info icon fully visible */
+#overlay-main .icon.info:hover, #overlay-main .icon.info:focus
+{
+	opacity: 1;
+}
+/* And add box-shadow on focus to override outline */
+#overlay-main .icon.info:focus
+{
+	box-shadow: -2px -2px 0px 1px white;
+	outline: none;
+}
 #overlay-main img
 {
 	max-width: 90vw;
@@ -464,29 +476,41 @@ h4 { font-weight: 600; margin-top: 10px; }
 	pointer-events: none;
 }
 /* Make the images (arrows and close) and nav-dots still take pointer events */
-#overlay-controls img, #overlay-controls .nav-dot { pointer-events: auto; }
-#overlay-controls img, #overlay-info #close
+#overlay-controls button, #overlay-controls .nav-dot { pointer-events: auto; }
+
+/* Style overlay buttons */
+.over-btn
 {
 	position: fixed;
 	background: rgba(0,0,0,0.5);
+	border: none;
 	border-radius: 50px;
 	box-sizing: border-box;
 	padding: 10px;
 	cursor: pointer;
 	transition: background 0.3s;
+	width: 50px;
+	height: 50px;
 }
-#overlay-controls img:hover
+.over-btn img
+{
+	width: 100%;
+	height: 100%;
+}
+/* On hover and focus darken background */
+.over-btn:hover, .over-btn:focus
 {
 	background: rgba(0,0,0,1);
 }
-#overlay-controls .arrow
+/* On focus add white box-shadow to replace outline */
+.over-btn:focus
 {
-	width: 50px;
+	box-shadow: 0px 0px 0px 3px white;
+	outline: none;
 }
 #overlay-controls #close, #overlay-info #close
 {
 	z-index: 25;
-	width: 50px;
 	top: 10px;
 	right: 10px;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -413,25 +413,42 @@ h4 { font-weight: 600; margin-top: 10px; }
 .img-base { width: 100%; }
 .img-container
 {
-	display: inline;
+	display: inline-block;
 	position: relative;
 }
-/* Style overlay info icon */
+/* Style overlay info section */
+#overlay-main .info-sect {
+	position: absolute;
+	width: 100%;
+	color: white;
+	bottom: 0px;
+	box-sizing: border-box;
+	background: rgba(0, 0, 0, 0.7);
+}
+.info-sect.open { padding: 25px 10px; }
+.info-sect:not(.open) .title, .info-sect:not(.open) .description {
+	display: none;
+}
+.info-sect .title {
+	font-weight: bold;
+	margin-bottom: 10px;
+	font-size: 1.5em;
+}
 #overlay-main .icon.info
 {
-    position: absolute;
+	position: absolute;
+	top: -50px;
+	right: -1px;
     width: 50px;
     height: 50px;
-    bottom: 4px;
-    right: -1px;
     background-size: 60%;
     background-repeat: no-repeat;
     background-position: 60% 50%;
-    background-color: rgba(0,0,0,0.95);
+    background-color: black;
     cursor: pointer;
     border-top-left-radius: 15px;
     border: none;
-    opacity: 0.5;
+    opacity: 0.7;
     transition: opacity 0.3s;
 }
 /* On focus and hover make info icon fully visible */

--- a/css/main.css
+++ b/css/main.css
@@ -185,6 +185,8 @@ h4 { font-weight: 600; margin-top: 10px; }
 	z-index: 0;
 	position: relative;
 	cursor: pointer;
+	background: white;
+	border: none;
 	width: calc(33% - 30px);
     padding: 5px;
     margin: 10px;
@@ -198,12 +200,12 @@ h4 { font-weight: 600; margin-top: 10px; }
 	width: 100%;
 	transition: all 0.3s;
 }
-.gallery-img:hover > img
+.gallery-img:hover > img, .gallery-img:focus > img
 {
 	filter: brightness(50%);
 	-webkit-filter: brightness(50%);
 }
-.gallery-img:hover > .icon
+.gallery-img:hover > .icon, .gallery-img:focus > .icon
 {
 	opacity: 1;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -209,6 +209,11 @@ h4 { font-weight: 600; margin-top: 10px; }
 {
 	opacity: 1;
 }
+/* Override default outline for gallery images */
+.gallery-img:focus
+{
+	outline: dashed 3px #D82F00;
+}
 .toggle-button
 {
 	display: inline-block;

--- a/gallery.html
+++ b/gallery.html
@@ -10,9 +10,12 @@ title: "Gallery"
 	<br>
 	Click an image to see a bigger version and use your arrow keys to go between images.
 </p>
-<div id="projects" class="toggle-button active">Project Photos</div>
-<div id="hobby" class="toggle-button">Hobby Photos</div>
+
+<button id="projects" class="toggle-button active" aria-pressed="true">Project Photos</button>
+<button id="hobby" class="toggle-button" aria-pressed="false">Hobby Photos</button>
+
 <div id="gallery-container">
+	<!-- Gallery images get loaded into here -->
 </div>
 
 <script>
@@ -198,8 +201,12 @@ title: "Gallery"
 	{
 		$(".gallery-img").hide();
 		$(".gallery-img.projects").css("display", "inline-block");
+
 		$(".toggle-button").removeClass("active");
+		$(".toggle-button").attr('aria-pressed', 'false');
 		$(this).addClass("active");
+		$(this).attr('aria-pressed', 'true');
+
 		galleryInstance.destroy();
 		galleryInstance = new Gallery(gallery, {showInfo: true});
 		location.hash = ""; //clear the hash
@@ -209,8 +216,12 @@ title: "Gallery"
 	{
 		$(".gallery-img").hide();
 		$(".gallery-img.hobby").css("display", "inline-block");
+
 		$(".toggle-button").removeClass("active");
+		$(".toggle-button").attr('aria-pressed', 'false');
 		$(this).addClass("active");
+		$(this).attr('aria-pressed', 'true');
+
 		galleryInstance.destroy();
 		galleryInstance = new Gallery(hobbyGallery);
 		location.hash = "#hobby-photos"; //update the hash for easy sharing

--- a/gallery.html
+++ b/gallery.html
@@ -152,20 +152,20 @@ title: "Gallery"
 	gallery.forEach(function(item, index)
 	{
 		$("#gallery-container").append(
-			'<div class="gallery-img projects">' +
+			'<button class="gallery-img projects">' +
 				'<div class="icon fullscreen"></div>' +
 				`<img data-id="${index}" src="${item.url}" alt="${item.alt}">` +
-			'</div>');
+			'</button>');
 	});
 
 	// Generate all hobby gallery tiles
 	hobbyGallery.forEach(function(item, index)
 	{
 		$("#gallery-container").append(
-			'<div class="gallery-img hobby">' +
+			'<button class="gallery-img hobby">' +
 				'<div class="icon fullscreen"></div>' +
 				`<img data-id="${index}" src="${item.url}" alt="${item.alt}">` +
-			'</div>');
+			'</button>');
 	});
 
 	// On click of gallery image

--- a/gallery.html
+++ b/gallery.html
@@ -149,7 +149,7 @@ title: "Gallery"
 		},
 	];
 
-	galleryInstance = new Gallery(gallery, {showInfo: true});
+	galleryInstance = new Gallery(gallery, { showInfo: true });
 
 	// Generate all the projects gallery tiles
 	gallery.forEach(function(item, index)
@@ -208,7 +208,7 @@ title: "Gallery"
 		$(this).attr('aria-pressed', 'true');
 
 		galleryInstance.destroy();
-		galleryInstance = new Gallery(gallery, {showInfo: true});
+		galleryInstance = new Gallery(gallery, { showInfo: true });
 		location.hash = ""; //clear the hash
 	});
 

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,60 +1,3 @@
-$(document).ready(function()
-{
-	$("#menu").click(function()
-	{
-		var topPadding = parseInt($("#header").css("padding-bottom"));
-		if(topPadding > 0) //close
-		{
-			$("#header").css("padding-bottom", "0");
-		}
-		else
-		{
-			$("#header").css("padding-bottom", "30");
-		}
-	});
-});
-
-$(window).on('resize', function()
-{
-	if($(window).width() > 600)
-	{
-		$("#header").css("padding-bottom", "0");
-	}
-});
-
-/* General Functions */
-
-// Shows an overlay with text, including a title and description, to explain something.
-function showInfo(title, description)
-{
-	$("body").append('<div id="overlay-info" class="overlay-transparent">' +
-		'<div class="centered info-cont">' +
-			'<div class="title">' + title + '</div>' +
-			'<div class="description">' + description + '</div>' +
-		'</div>' +
-		'<button id="close" class="over-btn">' +
-			'<img alt="Close info overlay" src="images/icons/cross.svg">' +
-		'</button>' +
-	'</div>');
-	$("#overlay-info .centered").click(function(event)
-	{
-		event.stopPropagation();
-	});
-	$("#overlay-info").click(closeInfo);
-	$("#overlay-info").fadeIn();
-	setPageBlur(true);
-}
-
-// Fades out and removes the info overlay specifically
-function closeInfo()
-{
-	setPageBlur(false);
-	$("#overlay-info").fadeOut(function()
-	{
-		$(this).remove();
-	});
-}
-
 // instantiates a gallery given a gallery data object, which contains info about all images to display
 // this can be either an array of hashes if you want more information in each gallery item
 // or an array of strings if you just need to display images
@@ -101,11 +44,11 @@ function Gallery(galleryData, options)
 	// Show the image with the given index in the galleryData
 	this.showImage = function(index)
 	{
+		setPageBlur(true);
 		self.currentImageIndex = index;
 		$("#overlay-controls .nav-dot").removeClass("active");
 		$($("#overlay-controls .nav-dot")[index]).addClass("active");
 		setOverlayImage(this.galleryData[index]); //set the image
-		setPageBlur(true);
 		$(".overlay").fadeIn(); //then fade in
 	}
 
@@ -229,37 +172,4 @@ function Gallery(galleryData, options)
 			return null;
 		}
 	}
-}
-
-// Blur the page and disable focus on it
-function setPageBlur(enableBlur)
-{
-	var elems = $("#header, .page-container, .footer");
-	var tabbableElements = $('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]');
-
-	if (enableBlur) {
-		elems.addClass("blur");
-		disableTabbingOnPage(tabbableElements);
-	}
-	else {
-		elems.removeClass("blur");
-		reEnableTabbingOnPage(tabbableElements);
-	}
-}
-
-// Source: https://www.webappcessibility.com/technical/keeping-tab-focus-within-modals/
-function disableTabbingOnPage(tabbableElements) {
-	$.each(tabbableElements, function (index, elem) {
-		// Ensure not in modal or modal controls
-		if($(elem).parents("#overlay-controls").length == 0
-			&& $(elem).parents("#overlay-main").length == 0) {
-			$(elem).attr('tabindex', '-1');
-		}
-	})
-}
-
-function reEnableTabbingOnPage(tabbableElements) {
-	$.each(tabbableElements, function (index, elem) {
-		$(elem).attr('tabindex', '0');
-	})
 }

--- a/js/main.js
+++ b/js/main.js
@@ -250,9 +250,10 @@ function setPageBlur(enableBlur)
 // Source: https://www.webappcessibility.com/technical/keeping-tab-focus-within-modals/
 function disableTabbingOnPage(tabbableElements) {
 	$.each(tabbableElements, function (index, elem) {
-		// Ensure not in modal or modal controls
+		// Ensure not in main modal, info modal or modal controls
 		if($(elem).parents("#overlay-controls").length == 0
-			&& $(elem).parents("#overlay-main").length == 0) {
+			&& $(elem).parents("#overlay-main").length == 0
+			&& $(elem).parents("#overlay-info").length == 0) {
 			$(elem).attr('tabindex', '-1');
 		}
 	})

--- a/js/main.js
+++ b/js/main.js
@@ -77,13 +77,13 @@ function Gallery(galleryData, options)
 		// Have overlay-controls first so it gets focus first
 		$("body").append(
 			'<div id="overlay-controls" class="overlay">' +
-				'<button id="close" class="over-btn">' +
+				'<button id="close" aria-label="Close overlay" class="over-btn">' +
 					'<img src="images/icons/cross.svg">' +
 				'</button>' +
-				'<button id="left" class="over-btn vertically-centered">' +
+				'<button id="left" aria-label="Previous image" class="over-btn vertically-centered">' +
 					'<img class="arrow" src="images/icons/chevron-thin-left.svg">' +
 				'</button>' +
-				'<button id="right" class="over-btn vertically-centered">' +
+				'<button id="right" aria-label="Next image" class="over-btn vertically-centered">' +
 					'<img class="arrow" src="images/icons/chevron-thin-right.svg">' +
 				'</button>' +
 				'<div class="gallery-nav">' + navigationDots + '</div>' +

--- a/js/main.js
+++ b/js/main.js
@@ -32,7 +32,9 @@ function showInfo(title, description)
 			'<div class="title">' + title + '</div>' +
 			'<div class="description">' + description + '</div>' +
 		'</div>' +
-		'<img id="close" src="images/icons/cross.svg">' +
+		'<button id="close" class="over-btn">' +
+			'<img alt="Close info overlay" src="images/icons/cross.svg">' +
+		'</button>' +
 	'</div>');
 	$("#overlay-info .centered").click(function(event)
 	{
@@ -72,14 +74,21 @@ function Gallery(galleryData, options)
 		var navigationDots = ""; // HTML for the navigation circles that show you how many images there are
 		navigationDots = '<div class="nav-dot"></div>'.repeat(galleryData.length); //repeat a single dot as many times as there are image
 
+		// Have overlay-controls first so it gets focus first
 		$("body").append(
-			'<div id="overlay-main" class="overlay overlay-transparent">' +
-			'</div>' +
 			'<div id="overlay-controls" class="overlay">' +
-				'<img id="close" src="images/icons/cross.svg">' +
-				'<img id="right" class="vertically-centered arrow" src="images/icons/chevron-thin-right.svg">' +
-				'<img id="left" class="vertically-centered arrow" src="images/icons/chevron-thin-left.svg">' +
+				'<button id="close" class="over-btn">' +
+					'<img src="images/icons/cross.svg">' +
+				'</button>' +
+				'<button id="left" class="over-btn vertically-centered">' +
+					'<img class="arrow" src="images/icons/chevron-thin-left.svg">' +
+				'</button>' +
+				'<button id="right" class="over-btn vertically-centered">' +
+					'<img class="arrow" src="images/icons/chevron-thin-right.svg">' +
+				'</button>' +
 				'<div class="gallery-nav">' + navigationDots + '</div>' +
+			'</div>' +
+			'<div id="overlay-main" class="overlay overlay-transparent">' +
 			'</div>'
 		);
 
@@ -175,7 +184,7 @@ function Gallery(galleryData, options)
 			var infoIcon = "";
 
 			if(options && options.showInfo)
-				infoIcon = '<div class="icon info"></div>';
+				infoIcon = '<button class="icon info"></button>';
 
 			if(url.indexOf("/thumbs") > -1) // if this is a thumbnail
 				url = url.replace("/thumbs",""); // use the full size image

--- a/js/main.js
+++ b/js/main.js
@@ -162,29 +162,34 @@ function Gallery(galleryData, options)
 
 	function setOverlayImage(galleryItem)
 	{
-		let url = getImageUrl(galleryItem);
-		let alt = typeof galleryItem == "object" ? galleryItem.alt : undefined;
 
 		if($("#overlay-main:visible").length > 0 && $("#overlay-main img").length > 0) //if there's already an image
 		{
 			$("#overlay-main .img-container").fadeOut(300, function() //fade it out
 			{
 				//then transition to new image by setting it, hiding it instantly, then fadin in
-				setOverlayHTMLWithImage(url, alt);
+				setOverlayHTMLWithImage(galleryItem);
 			  	$("#overlay-main .img-container").hide().fadeIn(300);
 			});
 		}
 		else
 		{
-			setOverlayHTMLWithImage(url, alt);
+			setOverlayHTMLWithImage(galleryItem);
 		}
 
-		function setOverlayHTMLWithImage(url, alt = undefined)
+		function setOverlayHTMLWithImage(galleryItem)
 		{
-			var infoIcon = "";
+			var infoSect = "";
+			var url = getImageUrl(galleryItem);
+			var alt = typeof galleryItem == "object" ? galleryItem.alt : undefined;
 
-			if(options && options.showInfo)
-				infoIcon = '<button class="icon info"></button>';
+			if(options && options.showInfo) {
+				infoSect = '<div class="info-sect">' +
+					'<button class="icon info"></button>' +
+					'<div class="title">' + galleryItem.title + '</div>' +
+					'<div class="description">' + galleryItem.description + '</div>' +
+				'</div>';
+			}
 
 			if(url.indexOf("/thumbs") > -1) // if this is a thumbnail
 				url = url.replace("/thumbs",""); // use the full size image
@@ -195,7 +200,7 @@ function Gallery(galleryData, options)
 			  		`<img src="${url}"` +
 			  			(alt ? `alt="${alt}"` : '') + // add all tag if it exists
 			  			'>' +
-			  		infoIcon +
+			  		infoSect +
 		  		'</div>' +
 		  	'</div>');
 
@@ -206,7 +211,7 @@ function Gallery(galleryData, options)
 
 		  	$("#overlay-main .img-container .icon.info").click(function()
 		  	{
-		  		showInfo(self.galleryData[self.currentImageIndex].title, self.galleryData[self.currentImageIndex].description)
+		  		$('#overlay-main .info-sect').toggleClass('open')
 		  	});
 		}
 	}


### PR DESCRIPTION
Makes the gallery accessible by making the controls into proper `<button>` elements, making focus remain within any open overlays, and making the focus state clear.

Also makes info on the gallery not show another overlay, since that was hard to fix accessibility with. See screenshots.

Resolves #11.

### Screenshots

Gallery info comparison:

| Before | After |
| --- | --- |
| ![screenshot from 2018-12-09 18-37-13](https://user-images.githubusercontent.com/3187531/49705140-b8b6c800-fbe1-11e8-8a74-46ad67220569.png) | ![screenshot from 2018-12-09 18-37-05](https://user-images.githubusercontent.com/3187531/49705141-b94f5e80-fbe1-11e8-9e4f-d305459ce365.png) |

 