### PR TITLE
Improve Homepage Responsiveness & Mobile Styling

### DIFF
--- a/css/index.scss
+++ b/css/index.scss
@@ -44,6 +44,20 @@ $desktop-img-size: 30rem;
   }
 }
 
+// On smaller desktop screens, shrink image
+@media (max-width: 1200px) {
+  .main-cont {
+    grid-template-columns: auto auto;
+
+    img {
+      height: 70%;
+      margin-left: 2rem;
+      align-self: center;
+    }
+    .text-cont { padding: 0 2rem; }
+  }
+}
+
 // Switch to mobile layout on tablets and
 @media (max-width: 1000px) {
   .main-cont {
@@ -55,14 +69,20 @@ $desktop-img-size: 30rem;
     box-shadow: none;
     margin-top: 0;
     border-radius: 0;
+    overflow: intial; // ensure <img> box-shadow shows
 
     img {
-      width: 100%;
+      width: 75%;
+      max-width: 400px;
       height: auto;
+      margin: auto;
+      box-shadow: 2px 4px 10px $shadow-color;
     }
     .text-cont {
       padding: 1.25rem 0;
       align-self: flex-start;
+
+      h1 { font-size: 3rem; }
     }
   }
 }


### PR DESCRIPTION
Fixes screen sizes like `1000px` having text cut-off on the homepage. Here's a comparison at that size and at mobile:

| Before | After | 
| --- | --- |
| ![viktorkoves com_](https://user-images.githubusercontent.com/3187531/75115799-a9297080-5627-11ea-8029-b04028c2e149.png) | ![localhost_4000_](https://user-images.githubusercontent.com/3187531/75115801-a9c20700-5627-11ea-8797-dc3eb254e41f.png) |
| ![Screenshot from 2020-02-23 10-32-48](https://user-images.githubusercontent.com/3187531/75115825-e42ba400-5627-11ea-86ce-3d247ea62b78.png) | ![Screenshot from 2020-02-23 10-32-55](https://user-images.githubusercontent.com/3187531/75115824-e2fa7700-5627-11ea-87c1-45eb1174b8b0.png) |


